### PR TITLE
Add some water to buffer the Vitamin C

### DIFF
--- a/21821_dragonfruitplant.cos
+++ b/21821_dragonfruitplant.cos
@@ -356,6 +356,7 @@ scrp 2 8 21821 12
 		targ from
 		stim writ from 78 1
 		chem 99 50
+		chem 33 0.25
 		targ ownr
 	endi
 	wait 25


### PR DESCRIPTION
Add 0.2 moles of water to buffer the potential for vitamin C speeding up a potentially fatal reaction with antigens 4 and 6. 
Both produce hotness as a side effect, which can lead to respiration failing if the creature becomes dehydrated.